### PR TITLE
Ignore SQLite WAL/SHM lock files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -135,4 +135,6 @@ dmypy.json
 .vscode/
 .claude/
 analytics.db
+analytics.db-shm
+analytics.db-wal
 analytics.salt


### PR DESCRIPTION
## Summary

- ``analytics.db-shm`` and ``analytics.db-wal`` (SQLite journal files created when the bot writes to ``analytics.db``) were showing up as untracked on every ``git status``.
- Add both to ``.gitignore`` alongside the already-ignored ``analytics.db``.

## Test plan

- [x] ``git check-ignore -v analytics.db-shm analytics.db-wal`` returns the new rules.
- [x] ``git status`` is clean with both files present on disk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)