### PR TITLE
Defer _queue creation to start_workers

### DIFF
--- a/bot/queue.py
+++ b/bot/queue.py
@@ -86,7 +86,9 @@ class DownloadTask:
     with_watermark: bool = True
 
 
-_queue: asyncio.Queue = asyncio.Queue()
+# Created in start_workers() so the Queue binds to the running event loop
+# (Python 3.9 asyncio.Queue captures the loop at construction time).
+_queue: asyncio.Queue = None  # type: ignore[assignment]
 _active: int = 0
 
 
@@ -213,6 +215,9 @@ async def _worker(wid: int):
 
 
 async def start_workers(count: Optional[int] = None):
+    global _queue
+    if _queue is None:
+        _queue = asyncio.Queue()
     n = count or MAX_CONCURRENT_DOWNLOADS
     for i in range(n):
         asyncio.create_task(_worker(i + 1))


### PR DESCRIPTION
## Summary
- Move `asyncio.Queue()` construction from module import time into `start_workers()` so it binds to the event loop that actually runs the workers.

## Background
On Python 3.9 `asyncio.Queue.__init__` captures the current event loop at construction. When `bot.queue` is imported, some loop exists (created by aiogram/prior imports); later `asyncio.run(main())` creates a fresh loop and starts the workers on it. The workers then fail immediately on their first `_queue.get()` with `RuntimeError: Future attached to a different loop`, so no downloads ever get processed.

This only manifested on my local dev setup (macOS, Python 3.9) — prod has been fine, likely because the prod environment ends up with a single loop across import + `asyncio.run`.

## Test plan
- [ ] `python main.py` locally with Python 3.9 starts without the "different loop" crash
- [ ] Bot processes a download end-to-end in the local test env
- [ ] Prod deploy still works (no behavior change when loops aren't split)

🤖 Generated with [Claude Code](https://claude.com/claude-code)