### PR TITLE
Strip TikTok auto-generated outro from method-1 downloads

### DIFF
--- a/bot/api/tiktok.py
+++ b/bot/api/tiktok.py
@@ -11,7 +11,8 @@ from dataclasses import dataclass
 from typing import AsyncIterator, Optional
 import httpx
 from aiogram.types import Message
-from settings import USER_AGENT
+from bot.overlay import strip_tiktok_outro
+from settings import OUTRO_TRIM_SECONDS, USER_AGENT
 
 class Retrying(Exception):
     pass
@@ -138,7 +139,9 @@ class TikTokAPI:
             f"method 1 (tiktok web downloadAddr): ok — "
             f"bytes={len(video.content)}, author={author}"
         )
-        return TikTokVideo(content=video.content, author=author, has_watermark=True)
+        # TikTok bakes an auto-generated outro (~4s) into downloadAddr MP4s.
+        content = await strip_tiktok_outro(video.content, OUTRO_TRIM_SECONDS)
+        return TikTokVideo(content=content, author=author, has_watermark=True)
 
     async def _primary_via_tikwm(self, client, url):
         logging.info("method 2 (tikwm wmplay): trying")

--- a/bot/overlay.py
+++ b/bot/overlay.py
@@ -2,7 +2,11 @@
 
 import asyncio
 import logging
+import os
+import re
 import shutil
+import tempfile
+from typing import Optional
 
 
 def _escape_drawtext(text: str) -> str:
@@ -11,6 +15,182 @@ def _escape_drawtext(text: str) -> str:
             .replace(":", r"\:")
             .replace("'", r"\'")
     )
+
+
+_SHOWINFO_PTS_RE = re.compile(r"pts_time:([\d.]+)")
+_SHOWINFO_ISKEY_RE = re.compile(r"iskey:(\d)")
+
+
+async def _probe_duration(path: str) -> Optional[float]:
+    proc = await asyncio.create_subprocess_exec(
+        "ffprobe", "-v", "error",
+        "-show_entries", "format=duration",
+        "-of", "default=nokey=1:noprint_wrappers=1",
+        path,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    out, err = await proc.communicate()
+    if proc.returncode != 0:
+        logging.warning(
+            f"ffprobe failed ({proc.returncode}): "
+            f"{err.decode(errors='replace')[:300]}"
+        )
+        return None
+    try:
+        return float(out.decode().strip())
+    except (ValueError, UnicodeDecodeError):
+        logging.warning("ffprobe returned non-numeric duration")
+        return None
+
+
+async def _detect_outro_start(path: str, duration: float) -> Optional[float]:
+    """Find the TikTok outro boundary in ``path``.
+
+    TikTok concatenates the outro onto the user's clip and inserts a keyframe
+    at the splice point; the frame itself is a strong scene change (the
+    outro's first frame is visually unrelated to the content). We run ffmpeg
+    with the scene filter + showinfo, then pick the latest keyframe scene
+    change that falls into the expected tail window (2.0–5.5s from end).
+    Returns None if nothing matches.
+    """
+    if duration < 4.0:
+        return None
+    tail_min = duration - 5.5
+    tail_max = duration - 2.0
+
+    proc = await asyncio.create_subprocess_exec(
+        "ffmpeg", "-loglevel", "info", "-y",
+        "-i", path,
+        "-vf", "select='gt(scene,0.3)',showinfo",
+        "-an", "-f", "null", "-",
+        stdout=asyncio.subprocess.DEVNULL,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    _, err = await proc.communicate()
+    if proc.returncode != 0:
+        return None
+
+    best: Optional[float] = None
+    for line in err.decode(errors="replace").splitlines():
+        if "showinfo" not in line:
+            continue
+        mk = _SHOWINFO_ISKEY_RE.search(line)
+        if not mk or mk.group(1) != "1":
+            continue
+        mt = _SHOWINFO_PTS_RE.search(line)
+        if not mt:
+            continue
+        t = float(mt.group(1))
+        if tail_min <= t <= tail_max:
+            if best is None or t > best:
+                best = t
+    return best
+
+
+async def _cut_reencode(path: str, to_seconds: float) -> Optional[bytes]:
+    """Frame-accurate cut via libx264 re-encode. Writes to a temp file (not a
+    pipe) so we can use ``+faststart`` without ``frag_keyframe`` — the latter
+    would extend the last fragment up to the next keyframe and pull the outro
+    back in."""
+    with tempfile.NamedTemporaryFile(suffix=".mp4", delete=False) as tmp_out:
+        out_path = tmp_out.name
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            "ffmpeg", "-loglevel", "error", "-y",
+            "-i", path,
+            "-to", f"{to_seconds:.3f}",
+            "-c:v", "libx264", "-preset", "veryfast", "-crf", "23",
+            "-c:a", "aac", "-b:a", "128k",
+            "-movflags", "+faststart",
+            "-f", "mp4", out_path,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        _, err = await proc.communicate()
+        if proc.returncode != 0:
+            logging.warning(
+                f"ffmpeg re-encode trim failed ({proc.returncode}): "
+                f"{err.decode(errors='replace')[:300]}"
+            )
+            return None
+        with open(out_path, "rb") as f:
+            data = f.read()
+        if not data:
+            return None
+        return data
+    finally:
+        try:
+            os.unlink(out_path)
+        except OSError:
+            pass
+
+
+async def strip_tiktok_outro(video_bytes: bytes,
+                             fallback_seconds: float = 0.0) -> bytes:
+    """Strip TikTok's auto-generated outro from a method-1 (downloadAddr) MP4.
+
+    Locates the real outro boundary via scene/keyframe detection and cuts one
+    frame before it with a libx264 re-encode (exact). If detection fails and
+    ``fallback_seconds > 0``, trims that many seconds off the tail as a last
+    resort — but that over-trims no-outro videos, so the default is 0 (leave
+    video untouched when unsure).
+    """
+    if not video_bytes:
+        return video_bytes
+    if not shutil.which("ffmpeg") or not shutil.which("ffprobe"):
+        return video_bytes
+
+    with tempfile.NamedTemporaryFile(suffix=".mp4", delete=False) as tmp:
+        tmp.write(video_bytes)
+        tmp_path = tmp.name
+
+    try:
+        duration = await _probe_duration(tmp_path)
+        if duration is None:
+            return video_bytes
+
+        outro_start = await _detect_outro_start(tmp_path, duration)
+        if outro_start is not None:
+            # Cut ~1 frame before the outro's first keyframe to exclude it.
+            target = max(0.1, outro_start - 0.04)
+            out = await _cut_reencode(tmp_path, target)
+            if out:
+                logging.info(
+                    f"outro stripped (detected at {outro_start:.2f}s): "
+                    f"{duration:.2f}s -> {target:.2f}s "
+                    f"(bytes {len(video_bytes)} -> {len(out)})"
+                )
+                return out
+            logging.warning("detected outro cut failed, falling back")
+
+        if fallback_seconds <= 0:
+            logging.info(
+                f"no outro detected in {duration:.2f}s video — leaving untouched"
+            )
+            return video_bytes
+
+        target = duration - fallback_seconds
+        if target <= 0.1:
+            logging.info(
+                f"skip outro trim: duration={duration:.2f}s "
+                f"<= trim={fallback_seconds:.2f}s"
+            )
+            return video_bytes
+
+        out = await _cut_reencode(tmp_path, target)
+        if not out:
+            return video_bytes
+        logging.info(
+            f"outro stripped (fallback {fallback_seconds:.1f}s): "
+            f"{duration:.2f}s -> {target:.2f}s "
+            f"(bytes {len(video_bytes)} -> {len(out)})"
+        )
+        return out
+    finally:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
 
 
 async def add_author_overlay(video_bytes: bytes, author: str) -> bytes:

--- a/settings.py
+++ b/settings.py
@@ -20,3 +20,8 @@ SUPABASE_KEY = config('SUPABASE_KEY', default='')
 
 # Download queue
 MAX_CONCURRENT_DOWNLOADS = config('MAX_CONCURRENT_DOWNLOADS', default=2, cast=int)
+
+# Fallback trim length (seconds) used when outro detection fails on a method-1
+# download. 0 = no fallback (trust detection). Only raise this if you see
+# outros slipping through; non-zero risks over-trimming no-outro videos.
+OUTRO_TRIM_SECONDS = config('OUTRO_TRIM_SECONDS', default=0.0, cast=float)


### PR DESCRIPTION
## Summary
- Detect the TikTok outro boundary in method-1 (`downloadAddr`) MP4s by looking for a scene-change-at-a-keyframe in the 2.0–5.5s tail window and cut one frame before it via libx264 re-encode.
- If no boundary is found, the video is returned untouched (no over-trim on clips that don't carry an outro).
- `OUTRO_TRIM_SECONDS` env var (default `0`) re-enables a fixed tail trim as a future knob if we see outros slipping through.

## Background
Method 1 served TikTok's watermarked MP4 with the ~4s auto-generated outro baked in (first-frame scene score ~0.85, always a GOP boundary — TikTok inserts a keyframe at the splice). Using that keyframe as the signal lets us cut exactly at the outro start; re-encoding avoids the previous keyframe-snap and audio-packet-trailing quirks we saw with stream-copy.

Verified against two real URLs:
- With outro: 10.543s → 6.500s (last content frame at 6.467s, outro's first frame at 6.533s excluded)
- Without outro: 13.067s → 13.067s, byte-identical output

## Test plan
- [ ] Send a known-outro video to the bot with watermark = on; verify the outro is gone and the last content beat is preserved
- [ ] Send a known-no-outro video; verify duration / bytes are unchanged
- [ ] Send a very short video (< 4s); verify no trim is attempted
- [ ] Check bot logs for `outro stripped (detected at X.XXs)` vs `no outro detected`

🤖 Generated with [Claude Code](https://claude.com/claude-code)