### PR TITLE
Delete watermark-prompt status message after batch finishes

### DIFF
--- a/bot/handlers/callbacks.py
+++ b/bot/handlers/callbacks.py
@@ -10,7 +10,7 @@ from aiogram.utils.exceptions import InvalidQueryID
 from bot import dp
 from bot import telemetry
 from bot.queue import (
-    pop_pending, enqueue, DownloadTask,
+    pop_pending, enqueue, DownloadTask, StatusMessage,
 )
 from settings import ANALYTICS_EXCLUDE_IDS
 
@@ -64,6 +64,11 @@ async def on_watermark_choice(callback: CallbackQuery):
         pass
 
     # ── queue the download(s) ─────────────────────────────────────
+    status_ref = StatusMessage(
+        chat_id=callback.message.chat.id,
+        message_id=callback.message.message_id,
+        remaining=n,
+    )
     for url in pt.urls:
         await enqueue(DownloadTask(
             url=url,
@@ -73,4 +78,5 @@ async def on_watermark_choice(callback: CallbackQuery):
             chat_type=pt.chat_type,
             track=pt.track,
             with_watermark=with_watermark,
+            status=status_ref,
         ))

--- a/bot/queue.py
+++ b/bot/queue.py
@@ -76,6 +76,18 @@ def _cleanup_stale():
 
 
 @dataclass
+class StatusMessage:
+    """Shared reference to the "⏳ Завантажую..." status message.
+
+    A single status message covers every URL in a batch, so `remaining`
+    is decremented by each task; the message is deleted when it hits 0.
+    """
+    chat_id: int
+    message_id: int
+    remaining: int
+
+
+@dataclass
 class DownloadTask:
     url: str
     message: Message
@@ -84,6 +96,7 @@ class DownloadTask:
     chat_type: str
     track: bool
     with_watermark: bool = True
+    status: Optional[StatusMessage] = None
 
 
 # Created in start_workers() so the Queue binds to the running event loop
@@ -200,6 +213,16 @@ async def _process(task: DownloadTask):
                 "An error occurred while trying to send a video.")
     finally:
         _active -= 1
+        if task.status is not None:
+            task.status.remaining -= 1
+            if task.status.remaining <= 0:
+                try:
+                    await bot.delete_message(
+                        task.status.chat_id,
+                        task.status.message_id,
+                    )
+                except Exception:
+                    pass
 
 
 async def _worker(wid: int):


### PR DESCRIPTION
## Summary
- The "⏳ Завантажую відео..." prompt (edited watermark-choice message) was left in chat after the video arrived.
- Added a `StatusMessage` shared between every `DownloadTask` in a batch (chat/message IDs + `remaining` counter).
- Worker deletes the message once the last task in the batch completes (success or failure), wrapped in try/except so a missing message can't break the worker.

## Test plan
- [x] Local dev bot (`@tiktok_download_test_bbot`): single TikTok link with watermark → status message disappears when the video sends.
- [x] Same with "without watermark" choice.
- [ ] Multi-URL message: status message only deletes after the last video sends.

🤖 Generated with [Claude Code](https://claude.com/claude-code)