### PR TITLE
Document local development workflow in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,20 @@ The script creates a venv, installs dependencies, builds a PyInstaller binary an
 | `-s` | Stop the bot |
 | `-h` | Show help |
 
+## Local Development
+
+For day-to-day development, skip the PyInstaller build and run `main.py` directly — it picks up code changes on the next restart without a rebuild.
+
+Use a **separate Telegram bot token** for local runs so you don't intercept updates intended for production. Create one with [@BotFather](https://t.me/BotFather) and put it in `.env` as `API_TOKEN`.
+
+```bash
+python3 -m venv venv
+./venv/bin/pip install -r requirements.txt
+./venv/bin/python main.py
+```
+
+Stop with `Ctrl+C`. Logs go to stdout.
+
 ## Built With
 
 - [aiogram](https://github.com/aiogram/aiogram) 2.19 — Telegram Bot framework

--- a/README.md
+++ b/README.md
@@ -2,6 +2,18 @@
 
 Telegram bot that downloads TikTok videos. Share a link in any chat where the bot is present — it will reply with the video. No commands needed.
 
+## Table of Contents
+
+- [Features](#features)
+- [Environment Variables](#environment-variables)
+  - [Required](#required)
+  - [Optional](#optional)
+- [Supabase Setup](#supabase-setup)
+- [Installation](#installation)
+  - [Deploy Script Flags](#deploy-script-flags)
+- [Local Development](#local-development)
+- [Built With](#built-with)
+
 ## Features
 
 - Automatic TikTok link detection (works in private chats, groups and channels)


### PR DESCRIPTION
## Summary
- Add a "Local Development" section to the README covering venv setup and running `main.py` directly, skipping the PyInstaller build for fast iteration.
- Recommend using a separate bot token for local runs so dev doesn't intercept prod updates.

## Test plan
- [x] README renders cleanly on GitHub.

🤖 Generated with [Claude Code](https://claude.com/claude-code)