### PR TITLE
Let users pick watermark mode and size

### DIFF
--- a/bot/analytics.py
+++ b/bot/analytics.py
@@ -148,6 +148,54 @@ async def get_recent_failures(limit: int = 10) -> list[dict]:
         return []
 
 
+# In-memory fallback for local dev when Supabase isn't configured.
+# Lost on restart; production uses the user_preferences table.
+_local_prefs: dict[int, str] = {}
+
+
+async def get_user_watermark_size(user_id: int) -> Optional[str]:
+    """Return the user's saved watermark preset key, or None if not set."""
+    if not _configured:
+        return _local_prefs.get(user_id)
+    try:
+        resp = await _get_client().get(
+            "/rest/v1/user_preferences",
+            params={
+                "anon_user": f"eq.{_hash_id(user_id)}",
+                "select": "watermark_size",
+                "limit": 1,
+            },
+        )
+        resp.raise_for_status()
+        rows = resp.json()
+        if rows:
+            return rows[0].get("watermark_size")
+        return None
+    except Exception:
+        logging.exception("analytics.get_user_watermark_size failed")
+        return None
+
+
+async def set_user_watermark_size(user_id: int, size: str) -> None:
+    """Upsert the user's watermark preset key."""
+    if not _configured:
+        _local_prefs[user_id] = size
+        return
+    try:
+        await _get_client().post(
+            "/rest/v1/user_preferences",
+            headers={
+                "Prefer": "return=minimal,resolution=merge-duplicates",
+            },
+            json={
+                "anon_user": _hash_id(user_id),
+                "watermark_size": size,
+            },
+        )
+    except Exception:
+        logging.exception("analytics.set_user_watermark_size failed")
+
+
 async def get_stats() -> dict:
     """Return a summary dict suitable for a /stats reply."""
     if not _configured:

--- a/bot/handlers/callbacks.py
+++ b/bot/handlers/callbacks.py
@@ -1,6 +1,6 @@
 # bot/handlers/callbacks.py
 #
-# Inline-button callback handlers (watermark choice).
+# Inline-button callback handlers (watermark choice + size picker).
 
 import logging
 
@@ -8,11 +8,24 @@ from aiogram.types import CallbackQuery
 from aiogram.utils.exceptions import InvalidQueryID
 
 from bot import dp
+from bot import analytics
 from bot import telemetry
+from bot.overlay import (
+    DEFAULT_WATERMARK_SIZE,
+    WATERMARK_PRESETS,
+    WATERMARK_SIZE_LABELS_UA,
+)
 from bot.queue import (
-    pop_pending, enqueue, DownloadTask, StatusMessage,
+    WATERMARK_MODES, pop_pending, enqueue, DownloadTask, StatusMessage,
 )
 from settings import ANALYTICS_EXCLUDE_IDS
+
+
+_MODE_LABELS_UA = {
+    "tt": "ватермарка TikTok",
+    "custom": "своя ватермарка",
+    "none": "без ватермарки",
+}
 
 
 async def _safe_answer(callback: CallbackQuery, text: str = None):
@@ -25,14 +38,17 @@ async def _safe_answer(callback: CallbackQuery, text: str = None):
 
 @dp.callback_query_handler(lambda cb: cb.data and cb.data.startswith("wm:"))
 async def on_watermark_choice(callback: CallbackQuery):
-    parts = callback.data.split(":", 2)  # wm : y/n : key
+    parts = callback.data.split(":", 2)  # wm : mode : key
     if len(parts) != 3:
         await _safe_answer(callback, "Помилка")
         return
 
-    _, choice, key = parts
-    pt = pop_pending(key)
+    _, mode, key = parts
+    if mode not in WATERMARK_MODES:
+        await _safe_answer(callback, "Помилка")
+        return
 
+    pt = pop_pending(key)
     if pt is None:
         await _safe_answer(callback, "Час вийшов, надішліть посилання ще раз.")
         try:
@@ -41,15 +57,21 @@ async def on_watermark_choice(callback: CallbackQuery):
             pass
         return
 
-    with_watermark = choice == "y"
-    wm_label = "з ватермаркою" if with_watermark else "без ватермарки"
     n = len(pt.urls)
+    wm_label = _MODE_LABELS_UA[mode]
 
-    # Telemetry — record each choice (respects exclude list for consistency
-    # with download events).
+    # Look up the user's saved size; only meaningful for the "custom" mode but
+    # a stale or unset value falls back to the default.
+    saved_size = await analytics.get_user_watermark_size(pt.user_id)
+    if saved_size not in WATERMARK_PRESETS:
+        saved_size = DEFAULT_WATERMARK_SIZE
+
+    # Telemetry — collapse the 3-way mode to the existing bool until we
+    # decide to track tt-vs-custom separately.
     if pt.user_id not in ANALYTICS_EXCLUDE_IDS:
+        any_watermark = mode != "none"
         for _ in range(n):
-            telemetry.record_watermark_choice(with_watermark, pt.chat_type)
+            telemetry.record_watermark_choice(any_watermark, pt.chat_type)
 
     # ── instant feedback ──────────────────────────────────────────
     await _safe_answer(callback)
@@ -77,6 +99,32 @@ async def on_watermark_choice(callback: CallbackQuery):
             chat_id=pt.chat_id,
             chat_type=pt.chat_type,
             track=pt.track,
-            with_watermark=with_watermark,
+            watermark_mode=mode,
+            watermark_size=saved_size,
             status=status_ref,
         ))
+
+
+@dp.callback_query_handler(lambda cb: cb.data and cb.data.startswith("wms:"))
+async def on_watermark_size_choice(callback: CallbackQuery):
+    parts = callback.data.split(":", 1)  # wms : preset
+    if len(parts) != 2 or parts[1] not in WATERMARK_PRESETS:
+        await _safe_answer(callback, "Помилка")
+        return
+
+    size = parts[1]
+    user_id = callback.from_user.id if callback.from_user else None
+    if user_id is None:
+        await _safe_answer(callback, "Помилка")
+        return
+
+    await analytics.set_user_watermark_size(user_id, size)
+    await _safe_answer(callback, "Збережено")
+
+    try:
+        await callback.message.edit_text(
+            f"✅ Розмір своєї ватермарки: <b>{WATERMARK_SIZE_LABELS_UA[size]}</b>",
+            parse_mode="HTML",
+        )
+    except Exception:
+        logging.debug("Could not edit watermark-size confirmation", exc_info=True)

--- a/bot/handlers/commands.py
+++ b/bot/handlers/commands.py
@@ -3,11 +3,46 @@
 import asyncio
 import logging
 from datetime import datetime
-from aiogram.types import Message
+from aiogram.types import (
+    Message, InlineKeyboardMarkup, InlineKeyboardButton,
+)
 from aiogram.utils.exceptions import BotBlocked, ChatNotFound, UserDeactivated
 from bot import bot, dp
 from bot import analytics
+from bot.overlay import (
+    DEFAULT_WATERMARK_SIZE,
+    WATERMARK_PRESETS,
+    WATERMARK_SIZE_LABELS_SHORT,
+    WATERMARK_SIZE_LABELS_UA,
+)
 from settings import ADMIN_ID
+
+
+def _watermark_size_keyboard(current: str) -> InlineKeyboardMarkup:
+    kb = InlineKeyboardMarkup(row_width=1)
+    for key in WATERMARK_PRESETS:
+        prefix = "✓ " if key == current else ""
+        kb.add(InlineKeyboardButton(
+            f"{prefix}{WATERMARK_SIZE_LABELS_UA[key]} ({WATERMARK_SIZE_LABELS_SHORT[key]})",
+            callback_data=f"wms:{key}",
+        ))
+    return kb
+
+
+@dp.message_handler(commands=["watermark_size"])
+async def cmd_watermark_size(message: Message):
+    """Let the user pick the size used for the custom @author overlay."""
+    uid = message.from_user.id if message.from_user else message.chat.id
+    saved = await analytics.get_user_watermark_size(uid)
+    if saved not in WATERMARK_PRESETS:
+        saved = DEFAULT_WATERMARK_SIZE
+
+    await message.reply(
+        "Оберіть розмір своєї ватермарки.\n"
+        f"Поточний: <b>{WATERMARK_SIZE_LABELS_UA[saved]}</b>",
+        parse_mode="HTML",
+        reply_markup=_watermark_size_keyboard(saved),
+    )
 
 
 @dp.message_handler(commands=["stats"])

--- a/bot/handlers/messages.py
+++ b/bot/handlers/messages.py
@@ -4,6 +4,11 @@ import logging
 from aiogram.types import Message, InlineKeyboardMarkup, InlineKeyboardButton
 from bot import dp
 from bot import analytics
+from bot.overlay import (
+    DEFAULT_WATERMARK_SIZE,
+    WATERMARK_PRESETS,
+    WATERMARK_SIZE_LABELS_SHORT,
+)
 from bot.queue import extract_urls, store_pending
 from settings import ANALYTICS_EXCLUDE_IDS
 
@@ -13,11 +18,15 @@ def _user_id(message: Message) -> int:
     return message.from_user.id if message.from_user else message.chat.id
 
 
-def _watermark_keyboard(key: str) -> InlineKeyboardMarkup:
-    kb = InlineKeyboardMarkup(row_width=2)
+def _watermark_keyboard(key: str, size: str) -> InlineKeyboardMarkup:
+    """Three-way watermark picker. The custom-overlay button is suffixed with
+    the user's saved size (T/S/M/L/XL) — set via /watermark_size."""
+    short = WATERMARK_SIZE_LABELS_SHORT.get(size, WATERMARK_SIZE_LABELS_SHORT[DEFAULT_WATERMARK_SIZE])
+    kb = InlineKeyboardMarkup(row_width=1)
     kb.add(
-        InlineKeyboardButton("✅ З ватермаркою", callback_data=f"wm:y:{key}"),
-        InlineKeyboardButton("❌ Без", callback_data=f"wm:n:{key}"),
+        InlineKeyboardButton("🎵 Ватермарка TikTok", callback_data=f"wm:tt:{key}"),
+        InlineKeyboardButton(f"✏️ Своя ({short})", callback_data=f"wm:custom:{key}"),
+        InlineKeyboardButton("❌ Без ватермарки", callback_data=f"wm:none:{key}"),
     )
     return kb
 
@@ -44,10 +53,14 @@ async def get_message(message: Message):
         track=track,
     )
 
+    saved_size = await analytics.get_user_watermark_size(uid)
+    if saved_size not in WATERMARK_PRESETS:
+        saved_size = DEFAULT_WATERMARK_SIZE
+
     try:
         await message.reply(
-            "Додати ватермарку автора?",
-            reply_markup=_watermark_keyboard(key),
+            "Оберіть тип ватермарки:",
+            reply_markup=_watermark_keyboard(key, saved_size),
         )
     except Exception:
         logging.debug("Could not send watermark question", exc_info=True)

--- a/bot/overlay.py
+++ b/bot/overlay.py
@@ -9,6 +9,35 @@ import tempfile
 from typing import Optional
 
 
+# Watermark size presets — each value is the divisor used in FFmpeg drawtext
+# `fontsize=h/N` (so larger N = smaller text). Bounds chosen so the smallest
+# remains legible on 720p video and the largest does not dominate the frame.
+WATERMARK_PRESETS: dict[str, int] = {
+    "tiny": 70,
+    "small": 54,
+    "medium": 43,
+    "large": 35,
+    "xl": 29,
+}
+DEFAULT_WATERMARK_SIZE = "small"
+
+# UI metadata for the size presets (kept next to the divisors so they stay in sync).
+WATERMARK_SIZE_LABELS_UA: dict[str, str] = {
+    "tiny": "Крихітна",
+    "small": "Маленька",
+    "medium": "Середня",
+    "large": "Велика",
+    "xl": "Дуже велика",
+}
+WATERMARK_SIZE_LABELS_SHORT: dict[str, str] = {
+    "tiny": "XS",
+    "small": "S",
+    "medium": "M",
+    "large": "L",
+    "xl": "XL",
+}
+
+
 def _escape_drawtext(text: str) -> str:
     return (
         text.replace("\\", "\\\\")
@@ -193,15 +222,17 @@ async def strip_tiktok_outro(video_bytes: bytes,
             pass
 
 
-async def add_author_overlay(video_bytes: bytes, author: str) -> bytes:
+async def add_author_overlay(video_bytes: bytes, author: str,
+                              size: str = DEFAULT_WATERMARK_SIZE) -> bytes:
     if not author or not shutil.which("ffmpeg"):
         return video_bytes
 
+    divisor = WATERMARK_PRESETS.get(size, WATERMARK_PRESETS[DEFAULT_WATERMARK_SIZE])
     text = _escape_drawtext(f"@{author}")
     vf = (
         f"drawtext=text='{text}'"
         ":fontcolor=white@0.85"
-        ":fontsize=h/27"
+        f":fontsize=h/{divisor}"
         ":borderw=2:bordercolor=black@0.6"
         ":x=w-tw-20:y=h-th-20"
     )

--- a/bot/queue.py
+++ b/bot/queue.py
@@ -24,7 +24,7 @@ from aiogram.utils.exceptions import RetryAfter, BadRequest
 
 from bot import bot
 from bot.api.tiktok import TikTokAPI, Retrying
-from bot.overlay import add_author_overlay
+from bot.overlay import add_author_overlay, DEFAULT_WATERMARK_SIZE
 from bot import analytics
 from bot import telemetry
 from settings import MAX_CONCURRENT_DOWNLOADS
@@ -89,6 +89,9 @@ class StatusMessage:
     remaining: int
 
 
+WATERMARK_MODES = ("tt", "custom", "none")
+
+
 @dataclass
 class DownloadTask:
     url: str
@@ -97,7 +100,12 @@ class DownloadTask:
     chat_id: int
     chat_type: str
     track: bool
-    with_watermark: bool = True
+    # "tt"     — prefer TikTok's own watermark (fall back to custom overlay
+    #            if the watermarked stream isn't available)
+    # "custom" — strip TikTok watermark, burn our @author overlay on top
+    # "none"   — clean video, no watermark
+    watermark_mode: str = "tt"
+    watermark_size: str = DEFAULT_WATERMARK_SIZE
     status: Optional[StatusMessage] = None
 
 
@@ -170,28 +178,45 @@ async def _process(task: DownloadTask):
     try:
         _cleanup_stale()
 
-        video = await _tiktok.download_video(task.url, prefer_watermarked=task.with_watermark)
+        prefer_tt = task.watermark_mode == "tt"
+        video = await _tiktok.download_video(task.url, prefer_watermarked=prefer_tt)
         if not video or not video.content:
             return
 
-        if task.with_watermark and video.author and not video.has_watermark:
-            logging.info(f"applying ffmpeg @author overlay for @{video.author}")
-            content = await add_author_overlay(video.content, video.author)
+        # Apply our custom overlay when:
+        #  - mode is "custom" (always), or
+        #  - mode is "tt" but TikTok's watermarked version wasn't available.
+        # "none" never overlays.
+        should_overlay = (
+            task.watermark_mode == "custom"
+            or (task.watermark_mode == "tt" and not video.has_watermark)
+        )
+        if should_overlay and video.author:
+            logging.info(
+                f"applying ffmpeg @author overlay for @{video.author} "
+                f"(mode={task.watermark_mode}, size={task.watermark_size})"
+            )
+            content = await add_author_overlay(
+                video.content, video.author, task.watermark_size,
+            )
         else:
             content = video.content
+
+        any_watermark = task.watermark_mode != "none"
 
         await send_video(task, content, author=video.author)
         if task.track:
             await analytics.record(task.user_id, task.chat_id, task.chat_type,
                                    "ok", len(content),
-                                   watermark=task.with_watermark)
+                                   watermark=any_watermark)
             telemetry.record_download(task.chat_type, len(content))
 
     except Retrying as e:
         logging.warning(f"Could not download video: {e} | url={task.url}")
         if task.track:
             await analytics.record(task.user_id, task.chat_id, task.chat_type,
-                                   "fail", watermark=task.with_watermark,
+                                   "fail",
+                                   watermark=task.watermark_mode != "none",
                                    url=task.url, reason=str(e))
             telemetry.record_failure(task.chat_type, "download_failed")
         await _reply_error(task,
@@ -201,7 +226,8 @@ async def _process(task: DownloadTask):
         err = str(e)
         if task.track:
             await analytics.record(task.user_id, task.chat_id, task.chat_type,
-                                   "error", watermark=task.with_watermark,
+                                   "error",
+                                   watermark=task.watermark_mode != "none",
                                    url=task.url, reason=err)
             telemetry.record_failure(task.chat_type, "send_failed")
         logging.warning(f"Failed to send video: {err}")

--- a/supabase_schema.sql
+++ b/supabase_schema.sql
@@ -35,6 +35,15 @@ CREATE TABLE IF NOT EXISTS known_users (
     last_seen   DOUBLE PRECISION NOT NULL
 );
 
+-- Per-user settings. Keyed by the same hashed anon_user used in `events` so
+-- prefs survive only as long as the local analytics.salt does — same trade-off
+-- as everything else here.
+CREATE TABLE IF NOT EXISTS user_preferences (
+    anon_user      TEXT PRIMARY KEY,
+    watermark_size TEXT NOT NULL DEFAULT 'small'
+        CHECK (watermark_size IN ('tiny','small','medium','large','xl'))
+);
+
 -- ── functions ────────────────────────────────────────────────────────
 
 -- Upsert: insert new user or update last_seen (keeps first_seen intact).


### PR DESCRIPTION
## Summary
- Watermark prompt is now a three-way choice: 🎵 TikTok / ✏️ Своя (XS/S/M/L/XL) / ❌ Без. The custom branch strips the TT watermark and burns an `@author` overlay; the TikTok branch keeps current behavior with the same fallback to custom overlay when no watermarked stream is available.
- Added `/watermark_size` command — picks one of five presets (Крихітна / Маленька / Середня / Велика / Дуже велика). The currently-saved option is marked with `✓`. Saved per user in a new `user_preferences` Supabase table (in-memory fallback when Supabase isn't configured, so local dev still works).
- Default custom-overlay size is **~37% smaller** than the previous fixed `h/27`. New presets: tiny=70, small=54 (default), medium=43, large=35, xl=29.

## DB
Run the new `user_preferences` block in [supabase_schema.sql](supabase_schema.sql) on your Supabase project before deploying. Service-role key bypasses RLS, matching how the other tables are accessed.

## Test plan
- [x] Local: 3-button prompt renders, all three modes produce expected videos
- [x] Local: `/watermark_size` shows current with `✓`, saving updates the `Своя (…)` suffix on next URL
- [ ] Prod: confirm `user_preferences` table is reachable (no Supabase error in logs)
- [ ] Prod: pick each size on `@tiktok_download_bot`, verify size is reflected in the next video
- [ ] Prod: verify TT watermark + None modes still work end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)