### PR TITLE
Shadow-block region-restricted TikTok requests

### DIFF
--- a/bot/analytics.py
+++ b/bot/analytics.py
@@ -196,6 +196,27 @@ async def set_user_watermark_size(user_id: int, size: str) -> None:
         logging.exception("analytics.set_user_watermark_size failed")
 
 
+async def get_filter_config() -> dict[str, str]:
+    """Return the shadow-filter tuning rules from the filter_config table.
+
+    Keys returned (when present): blocked_region_code, target_letters,
+    safe_letters, target_hashtags. Empty dict on any failure — callers must
+    treat that as "filter is a no-op" and not crash.
+    """
+    if not _configured:
+        return {}
+    try:
+        resp = await _get_client().get(
+            "/rest/v1/filter_config",
+            params={"select": "key,value"},
+        )
+        resp.raise_for_status()
+        return {row["key"]: row["value"] for row in resp.json() or []}
+    except Exception:
+        logging.exception("analytics.get_filter_config failed")
+        return {}
+
+
 async def get_stats() -> dict:
     """Return a summary dict suitable for a /stats reply."""
     if not _configured:

--- a/bot/api/tiktok.py
+++ b/bot/api/tiktok.py
@@ -23,6 +23,10 @@ class TikTokVideo:
     content: bytes
     author: Optional[str] = None
     has_watermark: bool = False
+    description: Optional[str] = None
+    region: Optional[str] = None
+    nickname: Optional[str] = None
+    signature: Optional[str] = None
 
 def retries(times: int):
     def decorator(func):
@@ -123,7 +127,12 @@ class TikTokAPI:
             raise Retrying(f"page status {response.status_code}")
 
         item = self._parse_universal_data(response.text)
-        author = (item.get("author") or {}).get("uniqueId")
+        author_obj = item.get("author") or {}
+        author = author_obj.get("uniqueId")
+        nickname = author_obj.get("nickname")
+        signature = author_obj.get("signature")
+        description = item.get("desc")
+        region = item.get("region") or author_obj.get("region")
         download_addr = (item.get("video") or {}).get("downloadAddr")
         if not download_addr:
             raise Retrying("downloadAddr missing in UNIVERSAL_DATA")
@@ -141,7 +150,9 @@ class TikTokAPI:
         )
         # TikTok bakes an auto-generated outro (~4s) into downloadAddr MP4s.
         content = await strip_tiktok_outro(video.content, OUTRO_TRIM_SECONDS)
-        return TikTokVideo(content=content, author=author, has_watermark=True)
+        return TikTokVideo(content=content, author=author, has_watermark=True,
+                           description=description, region=region,
+                           nickname=nickname, signature=signature)
 
     async def _primary_via_tikwm(self, client, url):
         logging.info("method 2 (tikwm wmplay): trying")
@@ -170,7 +181,12 @@ class TikTokAPI:
         if wm_url == data.get("play"):
             raise Retrying("tikwm wmplay equals play (no watermarked variant)")
 
-        author = (data.get("author") or {}).get("unique_id")
+        author_obj = data.get("author") or {}
+        author = author_obj.get("unique_id")
+        nickname = author_obj.get("nickname")
+        signature = author_obj.get("signature")
+        description = data.get("title")
+        region = data.get("region")
         cdn_headers = {"Referer": "https://www.tiktok.com/", **self._user_agent}
         video = await client.get(wm_url, headers=cdn_headers)
         if video.status_code != 200 or not video.content:
@@ -182,7 +198,9 @@ class TikTokAPI:
             f"method 2 (tikwm wmplay): ok — "
             f"bytes={len(video.content)}, author={author}"
         )
-        return TikTokVideo(content=video.content, author=author, has_watermark=True)
+        return TikTokVideo(content=video.content, author=author, has_watermark=True,
+                           description=description, region=region,
+                           nickname=nickname, signature=signature)
 
     async def _secondary_method(self, client, url):
         logging.info("method 3 (tiktok web no-watermark): trying")
@@ -191,7 +209,12 @@ class TikTokAPI:
             raise Retrying("Invalid response status code")
 
         item = self._parse_universal_data(response.text)
-        author = (item.get("author", {}) or {}).get("uniqueId")
+        author_obj = item.get("author", {}) or {}
+        author = author_obj.get("uniqueId")
+        nickname = author_obj.get("nickname")
+        signature = author_obj.get("signature")
+        description = item.get("desc")
+        region = item.get("region") or author_obj.get("region")
         video = item.get("video", {})
         cdn_headers = {"Referer": "https://www.tiktok.com/", **self._user_agent}
         for addr_key in ("playAddr", "downloadAddr"):
@@ -205,7 +228,9 @@ class TikTokAPI:
                 f"method 3 (tiktok web no-watermark): ok — "
                 f"addr={addr_key}, bytes={len(video_response.content)}, author={author}"
             )
-            return TikTokVideo(content=video_response.content, author=author)
+            return TikTokVideo(content=video_response.content, author=author,
+                               description=description, region=region,
+                               nickname=nickname, signature=signature)
 
         raise Retrying("No working video link found")
 

--- a/bot/filters/content_filter.py
+++ b/bot/filters/content_filter.py
@@ -1,0 +1,138 @@
+# bot/filters/content_filter.py
+#
+# Regional content filter for TikTok videos.
+#
+# Looks at the metadata that comes back with the video (region code,
+# description text, hashtags) and returns BLOCK or ALLOW. On BLOCK, the
+# caller shadow-fails with a generic error so the user can't tell the
+# filter exists.
+#
+# The active rules live in the Supabase `filter_config` table, NOT in this
+# file — call `await reload()` once at startup to pull them. Until then (or
+# if Supabase is unreachable), the filter is a no-op: ALLOW for everything.
+#
+# The core trick: compare two sets of "exclusive" Cyrillic letters — one set
+# appears only in the restricted-region language, the other only in the
+# safe-region language. Any safe-only letter anywhere in the description
+# flips the verdict to ALLOW (handles mixed dialects, quotes, code-switching).
+# Any target-only letter with zero safe-only letters → BLOCK regardless of
+# length: even two-character text like "хы" is unambiguous.
+
+from __future__ import annotations
+
+import logging
+from enum import Enum
+from typing import Optional
+
+from bot import analytics
+
+
+class FilterAction(Enum):
+    ALLOW = "allow"
+    BLOCK = "block"
+
+
+# ── runtime config (populated by reload()) ──────────────────────────────────
+
+_blocked_region_code: str = ""
+_target_letters: set[str] = set()
+_safe_letters: set[str] = set()
+_target_hashtags: tuple[str, ...] = ()
+
+
+def configure(
+    blocked_region_code: str,
+    target_letters: str,
+    safe_letters: str,
+    target_hashtags_csv: str,
+) -> None:
+    """Set the active rules in-process. Called by reload() and tests."""
+    global _blocked_region_code, _target_letters, _safe_letters, _target_hashtags
+    _blocked_region_code = (blocked_region_code or "").strip().upper()
+    _target_letters = set(target_letters or "")
+    _safe_letters = set(safe_letters or "")
+    _target_hashtags = tuple(
+        h.strip().lower()
+        for h in (target_hashtags_csv or "").split(",")
+        if h.strip()
+    )
+
+
+async def reload() -> None:
+    """Pull the active rules from Supabase. Logs and no-ops on failure."""
+    cfg = await analytics.get_filter_config()
+    configure(
+        blocked_region_code=cfg.get("blocked_region_code", ""),
+        target_letters=cfg.get("target_letters", ""),
+        safe_letters=cfg.get("safe_letters", ""),
+        target_hashtags_csv=cfg.get("target_hashtags", ""),
+    )
+    logging.info(
+        f"content_filter loaded: region={_blocked_region_code or '-'} "
+        f"target_letters={len(_target_letters)} "
+        f"safe_letters={len(_safe_letters)} "
+        f"hashtags={len(_target_hashtags)}"
+    )
+
+
+# ── implementation ──────────────────────────────────────────────────────────
+
+def _count_letters(text: str, letters: set[str]) -> int:
+    if not letters:
+        return 0
+    return sum(1 for ch in text if ch in letters)
+
+
+def _matched_hashtag(description: str) -> Optional[str]:
+    if not _target_hashtags:
+        return None
+    lower = description.lower()
+    for tag in _target_hashtags:
+        if tag in lower:
+            return tag
+    return None
+
+
+def evaluate(
+    description: Optional[str],
+    region: Optional[str],
+    nickname: Optional[str] = None,
+    signature: Optional[str] = None,
+    author: Optional[str] = None,
+) -> tuple[FilterAction, Optional[str]]:
+    """Return (action, reason). `reason` is a short tag for logging.
+
+    Description, nickname (display name), signature (bio) and author handle
+    (uniqueId) are all checked together: if a target signal appears in any
+    of them, it counts. This catches Russian creators with empty captions
+    but Cyrillic display names or bios, plus transliterated Russian handles
+    when the substring list includes the ASCII variants.
+    """
+    if (
+        _blocked_region_code
+        and region
+        and region.upper() == _blocked_region_code
+    ):
+        return FilterAction.BLOCK, "region"
+
+    text = " ".join(filter(None, [description, nickname, signature, author]))
+    if not text:
+        return FilterAction.ALLOW, None
+
+    tag = _matched_hashtag(text)
+    if tag:
+        return FilterAction.BLOCK, f"hashtag:{tag}"
+
+    target = _count_letters(text, _target_letters)
+    safe = _count_letters(text, _safe_letters)
+
+    # Any safe-only letter wins → ALLOW (covers surzhyk and Russian quotes
+    # inside Ukrainian text).
+    if safe >= 1:
+        return FilterAction.ALLOW, None
+
+    # No safe markers + at least one target-only letter → BLOCK.
+    if target >= 1:
+        return FilterAction.BLOCK, f"letters(t={target},len={len(text)})"
+
+    return FilterAction.ALLOW, None

--- a/bot/handlers/commands.py
+++ b/bot/handlers/commands.py
@@ -9,6 +9,7 @@ from aiogram.types import (
 from aiogram.utils.exceptions import BotBlocked, ChatNotFound, UserDeactivated
 from bot import bot, dp
 from bot import analytics
+from bot.filters import content_filter
 from bot.overlay import (
     DEFAULT_WATERMARK_SIZE,
     WATERMARK_PRESETS,
@@ -57,12 +58,17 @@ async def cmd_stats(message: Message):
 
     recipients = await analytics.get_broadcast_recipients()
 
+    total = stats['total_requests']
+    shadow = stats.get('shadow_blocks', 0) or 0
+    shadow_pct = round(shadow * 100 / total, 1) if total else 0.0
+
     lines = [
         "📊 <b>Статистика бота</b>",
         "",
-        f"Всього запитів: <b>{stats['total_requests']}</b>",
+        f"Всього запитів: <b>{total}</b>",
         f"  ✅ успішних: {stats['successful']}",
         f"  ❌ невдалих: {stats['failed']}",
+        f"  🛡 shadow blocked: {shadow} ({shadow_pct}%)",
         f"Унікальних користувачів: <b>{stats['unique_users']}</b>",
         f"Унікальних чатів: <b>{stats['unique_chats']}</b>",
         f"Завантажено відео: <b>{stats['total_video_mb']} MB</b>",
@@ -140,6 +146,15 @@ async def cmd_debug(message: Message):
 
     await message.reply("\n".join(lines), parse_mode="HTML",
                         disable_web_page_preview=True)
+
+
+@dp.message_handler(commands=["reload_filter"])
+async def cmd_reload_filter(message: Message):
+    """Re-pull shadow-filter rules from Supabase (admin only)."""
+    if ADMIN_ID and message.from_user.id != ADMIN_ID:
+        return
+    await content_filter.reload()
+    await message.reply("🛡 Filter rules reloaded from Supabase.")
 
 
 @dp.message_handler(commands=["broadcast"])

--- a/bot/queue.py
+++ b/bot/queue.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import asyncio
 import io
 import logging
+import random
 import re
 import time
 import uuid
@@ -27,7 +28,9 @@ from bot.api.tiktok import TikTokAPI, Retrying
 from bot.overlay import add_author_overlay, DEFAULT_WATERMARK_SIZE
 from bot import analytics
 from bot import telemetry
-from settings import MAX_CONCURRENT_DOWNLOADS
+from bot.filters import content_filter
+from bot.filters.content_filter import evaluate as filter_evaluate, FilterAction
+from settings import MAX_CONCURRENT_DOWNLOADS, SHADOW_FILTER_ENABLED
 
 _tiktok = TikTokAPI(headers={"Referer": "https://www.tiktok.com/"})
 
@@ -183,6 +186,38 @@ async def _process(task: DownloadTask):
         if not video or not video.content:
             return
 
+        if SHADOW_FILTER_ENABLED:
+            action, reason = filter_evaluate(
+                video.description, video.region,
+                nickname=video.nickname, signature=video.signature,
+                author=video.author,
+            )
+            logging.info(
+                f"filter check: action={action.name} reason={reason} "
+                f"author=@{video.author} nickname={(video.nickname or '')[:60]!r} "
+                f"region={video.region!r} desc={(video.description or '')[:100]!r} "
+                f"signature={(video.signature or '')[:100]!r}"
+            )
+            if action is FilterAction.BLOCK:
+                # Shadow-fail: the user sees the same generic "private/deleted"
+                # message as real failures. Random delay mimics network latency
+                # so the timing doesn't betray the filter.
+                await asyncio.sleep(random.uniform(1.0, 4.0))
+                logging.info(
+                    f"shadow_block: reason={reason} url={task.url} "
+                    f"author={video.author} region={video.region}"
+                )
+                if task.track:
+                    await analytics.record(task.user_id, task.chat_id, task.chat_type,
+                                           "shadow_block",
+                                           watermark=task.watermark_mode != "none",
+                                           url=task.url, reason=reason)
+                    telemetry.record_failure(task.chat_type, "shadow_block")
+                await _reply_error(task,
+                                   "Не вдалось завантажити це відео "
+                                   "(можливо приватне чи видалене).")
+                return
+
         # Apply our custom overlay when:
         #  - mode is "custom" (always), or
         #  - mode is "tt" but TikTok's watermarked version wasn't available.
@@ -275,6 +310,8 @@ async def start_workers(count: Optional[int] = None):
     global _queue
     if _queue is None:
         _queue = asyncio.Queue()
+    if SHADOW_FILTER_ENABLED:
+        await content_filter.reload()
     n = count or MAX_CONCURRENT_DOWNLOADS
     for i in range(n):
         asyncio.create_task(_worker(i + 1))

--- a/settings.py
+++ b/settings.py
@@ -21,6 +21,11 @@ SUPABASE_KEY = config('SUPABASE_KEY', default='')
 # Download queue
 MAX_CONCURRENT_DOWNLOADS = config('MAX_CONCURRENT_DOWNLOADS', default=2, cast=int)
 
+# Shadow-restrict downloads of Russian-origin TikToks. When triggered, the user
+# sees the same generic "private/deleted" failure message after a small delay,
+# making the filter indistinguishable from real failures. Set to 0 to disable.
+SHADOW_FILTER_ENABLED = config('SHADOW_FILTER_ENABLED', default=1, cast=int) == 1
+
 # Fallback trim length (seconds) used when outro detection fails on a method-1
 # download. 0 = no fallback (trust detection). Only raise this if you see
 # outros slipping through; non-zero risks over-trimming no-outro videos.

--- a/supabase_schema.sql
+++ b/supabase_schema.sql
@@ -44,6 +44,24 @@ CREATE TABLE IF NOT EXISTS user_preferences (
         CHECK (watermark_size IN ('tiny','small','medium','large','xl'))
 );
 
+-- Tunable rules for the shadow content filter (bot/filters/content_filter.py).
+-- Source of truth lives here, not in code, so the active rules don't ship with
+-- the repo. Update via Dashboard → SQL Editor:
+--   UPDATE filter_config SET value = '...' WHERE key = '...';
+-- Then run /reload_filter from the admin Telegram chat (or restart the bot).
+CREATE TABLE IF NOT EXISTS filter_config (
+    key   TEXT PRIMARY KEY,
+    value TEXT NOT NULL DEFAULT ''
+);
+
+-- Seed empty rows so the bot can always do an UPDATE later.
+INSERT INTO filter_config (key, value) VALUES
+    ('blocked_region_code', ''),
+    ('target_letters',      ''),
+    ('safe_letters',        ''),
+    ('target_hashtags',     '')
+ON CONFLICT (key) DO NOTHING;
+
 -- ── functions ────────────────────────────────────────────────────────
 
 -- Upsert: insert new user or update last_seen (keeps first_seen intact).
@@ -87,6 +105,7 @@ BEGIN
         'total_requests',   (SELECT COUNT(*) FROM events),
         'successful',       (SELECT COUNT(*) FROM events WHERE status = 'ok'),
         'failed',           (SELECT COUNT(*) FROM events WHERE status <> 'ok'),
+        'shadow_blocks',    (SELECT COUNT(*) FROM events WHERE status = 'shadow_block'),
         'unique_users',     (SELECT COUNT(DISTINCT anon_user) FROM events),
         'unique_chats',     (SELECT COUNT(DISTINCT anon_chat) FROM events),
         'total_video_bytes', COALESCE(


### PR DESCRIPTION
## Summary
- Adds a metadata filter that quietly fails downloads from a restricted region with the same "private/deleted" reply real failures already use, after a 1–4s delay so the timing doesn't betray the filter.
- Rules live in a new Supabase `filter_config` table (region code, exclusive Cyrillic letter sets, substring denylist) — the repo never carries active values. `/reload_filter` admin command pulls fresh rules without restart; `/stats` shows a shadow-block percentage.
- Conservative by design: any safe-region-exclusive Cyrillic letter anywhere in description, nickname, signature or author handle short-circuits to ALLOW, so surzhyk and quoted-region content pass through untouched.

## Files
- `bot/filters/content_filter.py` (new) — three-step evaluator: region → substring denylist → exclusive-letter heuristic. Empty config = no-op (allows everything).
- `bot/api/tiktok.py` — `TikTokVideo` now carries `description`, `region`, `nickname`, `signature`; all three download methods populate them.
- `bot/queue.py` — calls filter after download; on BLOCK: delay + `shadow_block` analytics row + generic reply. Logs `filter check:` line on every evaluation so you can tune.
- `bot/handlers/commands.py` — `/reload_filter` admin command; `/stats` line for shadow-block count and percentage.
- `bot/analytics.py` — `get_filter_config()` reads `filter_config`.
- `supabase_schema.sql` — `filter_config` table (key/value, seeded empty); `get_stats()` adds `shadow_blocks` count. Idempotent — safe to re-run.
- `settings.py` — `SHADOW_FILTER_ENABLED` env kill switch (default on).

## Deployment
- [x] Re-run `supabase_schema.sql` in prod Supabase SQL Editor.
- [x] Populate prod `filter_config` rows out-of-band (same `UPDATE filter_config SET value = ...` statements used in dev — values are not in this PR).
- [ ] Standard `git pull` + restart on Scaleway.

## Test plan
- [x] Russian video with target word → BLOCK (verified locally on dev bot)
- [x] Ukrainian creator, shared-Cyrillic-only caption → ALLOW
- [x] US creator, empty metadata → ALLOW
- [x] `/reload_filter` reflects Supabase changes without restart
- [ ] Post-deploy: spot-check BLOCK and ALLOW paths on prod bot
- [ ] Post-deploy: `/stats` includes the new `🛡 shadow blocked` line

🤖 Generated with [Claude Code](https://claude.com/claude-code)